### PR TITLE
Add page parameter for searchRepos()

### DIFF
--- a/lib/gogs-client.js
+++ b/lib/gogs-client.js
@@ -85,13 +85,15 @@ function API (apiUrl, requester) {
    * @param query {string}
    * @param uid {int} the id of the user whose repositories will be searched. 0 will search all
    * @param limit {int} the maximum number of results to return
+   * @param page {int} page number. Default is 1
    * @returns {Promise<array>} an array of repository objects
    */
-  _this.searchRepos = function (query, uid, limit) {
+  _this.searchRepos = function (query, uid, limit, page) {
     uid = uid || 0;
     limit = limit || 10;
+    page = page || 1;
 
-    return request('repos/search?q=' + query + '&uid=' + uid + '&limit=' + limit).then(stat.checkOkResponse);
+    return request('repos/search?q=' + query + '&uid=' + uid + '&limit=' + limit + '&page=' + page).then(stat.checkOkResponse);
   };
 
   /**


### PR DESCRIPTION
According to https://github.com/gogs/docs-api/tree/master/Repositories#parameters there should be page number as parameter, so that when the actual result exceeds the limit we can use paging.